### PR TITLE
Update google_cloud_storage_update_upload_action.rb

### DIFF
--- a/lib/fastlane/plugin/google_cloud_storage_update/actions/google_cloud_storage_update_check_file_action.rb
+++ b/lib/fastlane/plugin/google_cloud_storage_update/actions/google_cloud_storage_update_check_file_action.rb
@@ -78,9 +78,9 @@ module Fastlane
         ]
       end
 
-      # def self.supported?(platform)
-      #   true
-      # end
+      def self.is_supported?(platform)
+        true
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/google_cloud_storage_update/actions/google_cloud_storage_update_download_action.rb
+++ b/lib/fastlane/plugin/google_cloud_storage_update/actions/google_cloud_storage_update_download_action.rb
@@ -82,9 +82,9 @@ module Fastlane
         ]
       end
 
-      # def self.supported?(platform)
-      #   true
-      # end
+      def self.is_supported?(platform)
+        true
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/google_cloud_storage_update/actions/google_cloud_storage_update_upload_action.rb
+++ b/lib/fastlane/plugin/google_cloud_storage_update/actions/google_cloud_storage_update_upload_action.rb
@@ -81,9 +81,9 @@ module Fastlane
         ]
       end
 
-      # def self.supported?(platform)
-      #   true
-      # end
+      def self.is_supported?(platform)
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
The 'self.is_supported?' check seems required by Fastlane as stated [here](https://github.com/fastlane/fastlane/issues/676) and in the snippet below.

```
Run `fastlane env` to append the fastlane environment to your issue
/var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane_core/lib/fastlane_core/ui/interface.rb:129:in `crash!': [!] Implementing `is_supported?` for all actions is mandatory. Please update Fastlane::Actions::GoogleCloudStorageUploadAction (FastlaneCore::Interface::FastlaneCrash)
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/action.rb:103:in `is_supported?'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/runner.rb:300:in `verify_supported_os'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/runner.rb:226:in `execute_action'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/fast_file.rb:159:in `method_missing'
	from Fastfile:92:in `block (2 levels) in parsing_binding'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/lane.rb:33:in `call'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/runner.rb:45:in `chdir'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/runner.rb:45:in `execute'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/lane_manager.rb:47:in `cruise_lane'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/command_line_handler.rb:36:in `handle'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/commands_generator.rb:109:in `block (2 levels) in run'
	from /var/lib/gems/2.5.0/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
	from /var/lib/gems/2.5.0/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
	from /var/lib/gems/2.5.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:76:in `run!'
	from /var/lib/gems/2.5.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/commands_generator.rb:353:in `run'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/commands_generator.rb:42:in `start'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/fastlane/lib/fastlane/cli_tools_distributor.rb:122:in `take_off'
	from /var/lib/gems/2.5.0/gems/fastlane-2.191.0/bin/fastlane:23:in `<top (required)>'
	from /usr/local/bin/fastlane:23:in `load'
	from /usr/local/bin/fastlane:23:in `<main>'
```